### PR TITLE
Switch print function to logging

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -29,7 +29,8 @@ pc_fix = PointCloud(X_fix, columns=["x", "y", "z"])
 pc_mov = PointCloud(X_mov, columns=["x", "y", "z"])
 
 # Create simpleICP object, add point clouds, and run algorithm!
-icp = SimpleICP()
+# Set verbose to get information on stdout
+icp = SimpleICP(verbose=True)
 icp.add_point_clouds(pc_fix, pc_mov)
 H, X_mov_transformed, rigid_body_transformation_params, distance_residuals = icp.run(max_overlap_distance=1)
 ```


### PR DESCRIPTION
this resolves #37

You can get back to the previous behaviour by enabling the verbose flag in the SimpleICP class or by grabbing the simpleicp log directly, for example:

```
import logging
# simpleicp is the root logger. The SimpleICP class logs into
# simpleicp.simpleicp
log = logging.getLogger('simpleicp')
log.setLevel(logging.INFO)
# Redirect to any handler you want...
handler = logging.StreamHandler()
# You can use any kind of format you want...
handler.setFormatter(logging.Formatter('%(name)s %(message)s'))
log.addHandler(h)
```